### PR TITLE
Remove twitter from Dovetail

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ https://twitter.com/devontech
 ---
 
 ### Dovetail
-https://dovetailapp.com/<br />
-https://twitter.com/heydovetail
+https://dovetailapp.com/
 
 <img src="https://github.com/whitingx/ux-asset-management-systems/blob/master/img/dovetail.png" width="400" alt="Dovetail Screenshot">
 


### PR DESCRIPTION
The `heydovetail` Twitter account is no longer active unfortunately